### PR TITLE
Handle the NaN input

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,15 @@
 'use strict';
 var parseMs = require('parse-ms');
 var plur = require('plur');
+var numberIsNan = require('number-is-nan');
 
 module.exports = function (ms, opts) {
 	if (typeof ms !== 'number') {
 		throw new TypeError('Expected a number');
+	}
+
+	if (numberIsNan(ms)) {
+		return undefined;
 	}
 
 	opts = opts || {};

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "get-stdin": "^4.0.1",
     "meow": "^3.3.0",
+    "number-is-nan": "^1.0.0",
     "parse-ms": "^1.0.0",
     "plur": "^1.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -84,3 +84,7 @@ it('should work with verbose and secDecimalDigits options', function () {
 	assert.strictEqual(fn(1000 * 5 + 254), '5.2540 seconds');
 	assert.strictEqual(fn(33333), '33.3330 seconds');
 });
+
+it('should handle NaN input', function () {
+	assert.strictEqual(prettyMs(NaN), undefined);
+});


### PR DESCRIPTION
- Earlier a NaN input would give :-

    `NaNd NaNh NaNm NaNs`

- Returning `undefined` makes more sense, and can be handled by the
  application, instead of printing that string, which makes no sense at
  all.

Signed-off-by: Siddharth Kannan <kannan.siddharth12@gmail.com>