### PR TITLE
Add msDecimalDigits to allow higher precision

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports = function (ms, opts) {
 	opts = opts || {};
 
 	if (ms < 1000) {
-		return Math.ceil(ms) + (opts.verbose ? ' ' + plur('millisecond', Math.ceil(ms)) : 'ms');
+		var msDecimalDigits = typeof opts.msDecimalDigits === 'number' ? opts.msDecimalDigits : 0;
+		return ms.toFixed(msDecimalDigits) + (opts.verbose ? ' ' + plur('millisecond', Math.ceil(ms)) : 'ms');
 	}
 
 	var ret = [];

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (ms, opts) {
 
 	if (ms < 1000) {
 		var msDecimalDigits = typeof opts.msDecimalDigits === 'number' ? opts.msDecimalDigits : 0;
-		return ms.toFixed(msDecimalDigits) + (opts.verbose ? ' ' + plur('millisecond', Math.ceil(ms)) : 'ms');
+		return (msDecimalDigits ? ms.toFixed(msDecimalDigits) : Math.ceil(ms)) + (opts.verbose ? ' ' + plur('millisecond', Math.ceil(ms)) : 'ms');
 	}
 
 	var ret = [];

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,13 @@ Default: `1`
 
 Number of digits to appear after the seconds decimal point.
 
+##### msDecimalDigits
+
+Type: `number`  
+Default: `0`
+
+Number of digits to appear after the milliseconds decimal point.
+
 ##### compact
 
 Type: `boolean`  

--- a/test.js
+++ b/test.js
@@ -29,8 +29,8 @@ it('should have a secDecimalDigits option', function () {
 });
 
 it('should have a msDecimalDigits option', function () {
-	assert.strictEqual(prettyMs(33.333), '33ms');
-	assert.strictEqual(prettyMs(33.333, {msDecimalDigits: 0}), '33ms');
+	assert.strictEqual(prettyMs(33.333), '34ms');
+	assert.strictEqual(prettyMs(33.333, {msDecimalDigits: 0}), '34ms');
 	assert.strictEqual(prettyMs(33.333, {msDecimalDigits: 4}), '33.3330ms');
 });
 

--- a/test.js
+++ b/test.js
@@ -28,6 +28,12 @@ it('should have a secDecimalDigits option', function () {
 	assert.strictEqual(prettyMs(33333, {secDecimalDigits: 4}), '33.3330s');
 });
 
+it('should have a msDecimalDigits option', function () {
+	assert.strictEqual(prettyMs(33.333), '33ms');
+	assert.strictEqual(prettyMs(33.333, {msDecimalDigits: 0}), '33ms');
+	assert.strictEqual(prettyMs(33.333, {msDecimalDigits: 4}), '33.3330ms');
+});
+
 it('should have a verbose option', function () {
 	var fn = function (ms) {
 		return prettyMs(ms, {verbose: true});
@@ -83,6 +89,21 @@ it('should work with verbose and secDecimalDigits options', function () {
 	assert.strictEqual(fn(1000 * 2 + 400), '2.4000 seconds');
 	assert.strictEqual(fn(1000 * 5 + 254), '5.2540 seconds');
 	assert.strictEqual(fn(33333), '33.3330 seconds');
+});
+
+it('should work with verbose and msDecimalDigits options', function () {
+	var fn = function (ms) {
+		return prettyMs(ms, {
+			verbose: true,
+			msDecimalDigits: 4
+		});
+	};
+
+	assert.strictEqual(fn(1), '1.0000 millisecond');
+	assert.strictEqual(fn(1 + .4), '1.4000 milliseconds');
+	assert.strictEqual(fn(1 * 2 + .400), '2.4000 milliseconds');
+	assert.strictEqual(fn(1 * 5 + .254), '5.2540 milliseconds');
+	assert.strictEqual(fn(33.333), '33.3330 milliseconds');
 });
 
 it('should throw on invalid', function () {


### PR DESCRIPTION
There are scenarios where a higher precision than single milliseconds is needed (e.g. when measuring response times using `process.hrtime`). It would be nice if these could be formatted using `pretty-ms` without losing that all sub-millisecond precision.

This PR adds an option `msDecimalDigits` analogous to `secDecimalDigits` for specifying what precision is used when display millisecond values.