### PR TITLE
Add option to keep decimals on whole seconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ module.exports = (ms, opts) => {
 
 	const sec = ms / 1000 % 60;
 	const secDecimalDigits = typeof opts.secDecimalDigits === 'number' ? opts.secDecimalDigits : 1;
-	const secStr = sec.toFixed(secDecimalDigits).replace(/\.0+$/, '');
+	const secFixed = sec.toFixed(secDecimalDigits);
+	const secStr = opts.keepDecimalsOnWholeSeconds ? secFixed : secFixed.replace(/\.0+$/, '');
 	add(sec, 'second', 's', secStr);
 
 	return ret.join(' ');

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,15 @@ Number of digits to appear after the milliseconds decimal point.
 
 Useful in combination with [`process.hrtime()`](https://nodejs.org/api/process.html#process_process_hrtime).
 
+##### keepDecimalsOnWholeSeconds
+
+Type: `boolean`<br>
+Default: `false`
+
+Keep milliseconds on whole seconds: `13s` → `13.0s`.
+
+Useful when you are showing a number of seconds spent on an operation and don't want the width of the output to change when hitting a whole number.
+
 ##### compact
 
 Type: `boolean`<br>

--- a/test.js
+++ b/test.js
@@ -38,6 +38,11 @@ test('have a msDecimalDigits option', t => {
 	t.is(m(33.333, {msDecimalDigits: 4}), '33.3330ms');
 });
 
+test('have a keepDecimalsOnWholeSeconds option', t => {
+	t.is(m(1000 * 33, {secDecimalDigits: 2, keepDecimalsOnWholeSeconds: true}), '33.00s');
+	t.is(m(1000 * 33.00004, {secDecimalDigits: 2, keepDecimalsOnWholeSeconds: true}), '33.00s');
+});
+
 test('have a verbose option', t => {
 	const fn = ms => m(ms, {verbose: true});
 


### PR DESCRIPTION
Currently: `prettyMs(33000.04, {secDecimalDigits: 2})`  → `33s`

With this PR, you can pass a `keepDecimalsOnWholeSeconds: true` option to instead return `33.00s`.

See [issue #20](https://github.com/sindresorhus/pretty-ms/issues/20#issuecomment-331382700) for background.