### PR TITLE
Remove `plur` dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const parseMs = require('parse-ms');
-const plur = require('plur');
+
+const plur = (word, count) => count === 1 ? word : word + 's';
 
 module.exports = (ms, opts) => {
 	if (!Number.isFinite(ms)) {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "hrtime"
   ],
   "dependencies": {
-    "parse-ms": "^1.0.0",
-    "plur": "^2.1.2"
+    "parse-ms": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
This module depends on [plur](https://github.com/sindresorhus/plur) in order to pluralise words. In turn, plur imports [this long list](https://github.com/sindresorhus/irregular-plurals/blob/master/irregular-plurals.json) of irregular plurals, none of which are relevant to pretty-ms since it doesn't need to know that the plural of 'goose' is 'geese'.

By replacing that import with the following line...

```js
const plur = (word, count) => count === 1 ? word : word + 's';
```

...we can shrink the size of the package by about two thirds (depending on how exactly you minify and compress). For Rollup users, it also means that they don't need to use rollup-plugin-json to consume this module.