### PR TITLE
Fix `{secDecimalDigits: 0}` rounding rollover issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,15 @@ module.exports = (ms, options = {}) => {
 		ret.push((valueString || value) + postfix);
 	};
 
+	const secDecimalDigits = typeof options.secDecimalDigits === 'number' ? options.secDecimalDigits : 1;
+
+	if (secDecimalDigits < 1) {
+		const diff = 1000 - (ms % 1000);
+		if (diff < 500) {
+			ms += diff;
+		}
+	}
+
 	const parsed = parseMs(ms);
 
 	add(Math.trunc(parsed.days / 365), 'year', 'y');
@@ -38,7 +47,6 @@ module.exports = (ms, options = {}) => {
 	}
 
 	const sec = ms / 1000 % 60;
-	const secDecimalDigits = typeof options.secDecimalDigits === 'number' ? options.secDecimalDigits : 1;
 	const secFixed = sec.toFixed(secDecimalDigits);
 	const secStr = options.keepDecimalsOnWholeSeconds ? secFixed : secFixed.replace(/\.0+$/, '');
 	add(sec, 'second', 's', secStr);

--- a/test.js
+++ b/test.js
@@ -124,3 +124,12 @@ test('throw on invalid', t => {
 		m(Infinity);
 	});
 });
+
+test('properly rounds milliseconds with secDecimalDigits', t => {
+	const fn = ms => m(ms, {verbose: true, secDecimalDigits: 0});
+	t.is(fn(179700), '3 minutes');
+	t.is(fn((365 * 24 * 3600 * 1e3) - 1), '1 year');
+	t.is(fn((24 * 3600 * 1e3) - 1), '1 day');
+	t.is(fn((3600 * 1e3) - 1), '1 hour');
+	t.is(fn((2 * 3600 * 1e3) - 1), '2 hours');
+});


### PR DESCRIPTION
closes #26

- Adds tests for various off by 1ms differences in the` pretty-ms` function
- Uses ms difference to fix the issue before parse, assuming user has set `secDecimalDigits` to `0`