### PR TITLE
Add `unitCount` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = (ms, options = {}) => {
 	add(sec, 'second', 's', secStr);
 
 	if (typeof options.unitsToShow === 'number') {
-		return ret.slice(0, options.unitsToShow).join(' ');
+		return '~' + ret.slice(0, options.unitsToShow).join(' ');
 	}
 
 	return ret.join(' ');

--- a/index.js
+++ b/index.js
@@ -51,5 +51,9 @@ module.exports = (ms, options = {}) => {
 	const secStr = options.keepDecimalsOnWholeSeconds ? secFixed : secFixed.replace(/\.0+$/, '');
 	add(sec, 'second', 's', secStr);
 
+	if (typeof options.unitsToShow === 'number') {
+		return ret.slice(0, options.unitsToShow).join(' ');
+	}
+
 	return ret.join(' ');
 };

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = (ms, options = {}) => {
 	add(sec, 'second', 's', secStr);
 
 	if (typeof options.unitsToShow === 'number') {
-		return '~' + ret.slice(0, options.unitsToShow).join(' ');
+		return '~' + ret.slice(0, Math.max(options.unitsToShow, 1)).join(' ');
 	}
 
 	return ret.join(' ');

--- a/index.js
+++ b/index.js
@@ -25,6 +25,15 @@ module.exports = (ms, options = {}) => {
 		ret.push((valueString || value) + postfix);
 	};
 
+	const secDecimalDigits = typeof options.secDecimalDigits === 'number' ? options.secDecimalDigits : 1;
+
+	if (secDecimalDigits < 1) {
+		const diff = 1000 - (ms % 1000);
+		if (diff < 500) {
+			ms += diff;
+		}
+	}
+
 	const parsed = parseMs(ms);
 
 	add(Math.trunc(parsed.days / 365), 'year', 'y');
@@ -38,7 +47,6 @@ module.exports = (ms, options = {}) => {
 	}
 
 	const sec = ms / 1000 % 60;
-	const secDecimalDigits = typeof options.secDecimalDigits === 'number' ? options.secDecimalDigits : 1;
 	const secFixed = sec.toFixed(secDecimalDigits);
 	const secStr = options.keepDecimalsOnWholeSeconds ? secFixed : secFixed.replace(/\.0+$/, '');
 	add(sec, 'second', 's', secStr);

--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ module.exports = (ms, options = {}) => {
 	const secStr = options.keepDecimalsOnWholeSeconds ? secFixed : secFixed.replace(/\.0+$/, '');
 	add(sec, 'second', 's', secStr);
 
-	if (typeof options.unitsToShow === 'number') {
-		return '~' + ret.slice(0, Math.max(options.unitsToShow, 1)).join(' ');
+	if (typeof options.unitCount === 'number') {
+		return '~' + ret.slice(0, Math.max(options.unitCount, 1)).join(' ');
 	}
 
 	return ret.join(' ');

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ Default: `false`
 
 Only show the first unit: `1h 10m` → `~1h`.
 
-##### unitsToShow
+##### unitCount
 
 Type: `number`<br>
 Default: `infinity`

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ Only show the first unit: `1h 10m` → `~1h`.
 Type: `number`<br>
 Default: `Infinity`
 
-Number of units to show.
+Number of units to show. Setting `compact` to `true` overrides this option.
 
 ##### verbose
 

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,13 @@ Default: `false`
 
 Only show the first unit: `1h 10m` → `~1h`.
 
+##### unitsToShow
+
+Type: `number`<br>
+Default: `infinity`
+
+Number of units to show.
+
 ##### verbose
 
 Type: `boolean`<br>

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ test('have a compact option', t => {
 	t.is(m(1000 * 60 * 67 * 24 * 465, {compact: true}), '~1y');
 });
 
-test('limit number of units shown', t => {
+test('have a unitCount option', t => {
 	t.is(m(1000 * 60, {unitCount: 0}), '~1m');
 	t.is(m(1000 * 60, {unitCount: 1}), '~1m');
 	t.is(m(1000 * 60 * 67, {unitCount: 1}), '~1h');
@@ -95,6 +95,15 @@ test('work with verbose and compact options', t => {
 	t.is(fn(1000 * 60 * 67 * 24 * 750), '~2 years');
 });
 
+test('work with verbose and unitCount options', t => {
+	t.is(m(1000 * 60, {verbose: true, unitCount: 1}), '~1 minute');
+	t.is(m(1000 * 60 * 67, {verbose: true, unitCount: 1}), '~1 hour');
+	t.is(m(1000 * 60 * 67, {verbose: true, unitCount: 2}), '~1 hour 7 minutes');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {verbose: true, unitCount: 1}), '~1 year');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {verbose: true, unitCount: 2}), '~1 year 154 days');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {verbose: true, unitCount: 3}), '~1 year 154 days 6 hours');
+});
+
 test('work with verbose and secDecimalDigits options', t => {
 	const fn = ms => m(ms, {
 		verbose: true,
@@ -119,6 +128,12 @@ test('work with verbose and msDecimalDigits options', t => {
 	t.is(fn((1 * 2) + 0.400), '2.4000 milliseconds');
 	t.is(fn((1 * 5) + 0.254), '5.2540 milliseconds');
 	t.is(fn(33.333), '33.3330 milliseconds');
+});
+
+test('compact option overrides unitCount option', t => {
+	t.is(m(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 1}), '~1 year');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 2}), '~1 year');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 3}), '~1 year');
 });
 
 test('throw on invalid', t => {

--- a/test.js
+++ b/test.js
@@ -25,6 +25,16 @@ test('have a compact option', t => {
 	t.is(m(1000 * 60 * 67 * 24 * 465, {compact: true}), '~1y');
 });
 
+test('limit number of units shown', t => {
+	t.is(m(1000 * 60, {unitsToShow: 0}), '~1m');
+	t.is(m(1000 * 60, {unitsToShow: 1}), '~1m');
+	t.is(m(1000 * 60 * 67, {unitsToShow: 1}), '~1h');
+	t.is(m(1000 * 60 * 67, {unitsToShow: 2}), '~1h 7m');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {unitsToShow: 1}), '~1y');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {unitsToShow: 2}), '~1y 154d');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {unitsToShow: 3}), '~1y 154d 6h');
+});
+
 test('have a secDecimalDigits option', t => {
 	t.is(m(10000), '10s');
 	t.is(m(33333), '33.3s');

--- a/test.js
+++ b/test.js
@@ -74,6 +74,18 @@ test('have a verbose option', t => {
 	t.is(fn(1000 * 60 * 67 * 24 * 465), '1 year 154 days 6 hours');
 });
 
+test('have a separateMs option', t => {
+	t.is(m(1100, {separateMs: false}), '1.1s');
+	t.is(m(1100, {separateMs: true}), '1s 100ms');
+});
+
+test('have a formatSubMs option', t => {
+	t.is(m(0.400, {formatSubMs: true}), '400µs');
+	t.is(m(0.123571, {formatSubMs: true}), '123µs 571ns');
+	t.is(m(0.123456789, {formatSubMs: true}), '123µs 456ns');
+	t.is(m((60 * 60 * 1000) + (23 * 1000) + 433 + 0.123456, {formatSubMs: true}), '1h 23s 433ms 123µs 456ns');
+});
+
 test('work with verbose and compact options', t => {
 	const fn = ms => m(ms, {
 		verbose: true,
@@ -130,10 +142,22 @@ test('work with verbose and msDecimalDigits options', t => {
 	t.is(fn(33.333), '33.3330 milliseconds');
 });
 
+test('work with verbose and formatSubMs options', t => {
+	t.is(m(0.400, {formatSubMs: true, verbose: true}), '400 microseconds');
+	t.is(m(0.123571, {formatSubMs: true, verbose: true}), '123 microseconds 571 nanoseconds');
+	t.is(m(0.123456789, {formatSubMs: true, verbose: true}), '123 microseconds 456 nanoseconds');
+	t.is(m(0.001, {formatSubMs: true, verbose: true}), '1 microsecond');
+});
+
 test('compact option overrides unitCount option', t => {
 	t.is(m(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 1}), '~1 year');
 	t.is(m(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 2}), '~1 year');
 	t.is(m(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 3}), '~1 year');
+});
+
+test('work with separateMs and formatSubMs options', t => {
+	t.is(m(1010.340067, {separateMs: true, formatSubMs: true}), '1s 10ms 340µs 67ns');
+	t.is(m(((60 * 1000) + 34 + 0.000005), {separateMs: true, formatSubMs: true}), '1m 34ms 5ns');
 });
 
 test('throw on invalid', t => {

--- a/test.js
+++ b/test.js
@@ -124,3 +124,12 @@ test('throw on invalid', t => {
 		m(Infinity);
 	});
 });
+
+test('properly rounds milliseconds with secDecimalDigits', t => {
+	const fn = ms => m(ms, {verbose: true, secDecimalDigits: 0});
+	t.is(fn(179700), '3 minutes');
+	t.is(fn((365 * 24 * 3600 * 1e3) - 1), '1 year');
+	t.is(fn((24 * 3600 * 1e3) - 1), '1 day');
+	t.is(fn((3600 * 1e3) - 1), '1 hour');
+	t.is(fn((2 * 3600 * 1e3) - 1), '2 hours');
+});

--- a/test.js
+++ b/test.js
@@ -26,13 +26,13 @@ test('have a compact option', t => {
 });
 
 test('limit number of units shown', t => {
-	t.is(m(1000 * 60, {unitsToShow: 0}), '~1m');
-	t.is(m(1000 * 60, {unitsToShow: 1}), '~1m');
-	t.is(m(1000 * 60 * 67, {unitsToShow: 1}), '~1h');
-	t.is(m(1000 * 60 * 67, {unitsToShow: 2}), '~1h 7m');
-	t.is(m(1000 * 60 * 67 * 24 * 465, {unitsToShow: 1}), '~1y');
-	t.is(m(1000 * 60 * 67 * 24 * 465, {unitsToShow: 2}), '~1y 154d');
-	t.is(m(1000 * 60 * 67 * 24 * 465, {unitsToShow: 3}), '~1y 154d 6h');
+	t.is(m(1000 * 60, {unitCount: 0}), '~1m');
+	t.is(m(1000 * 60, {unitCount: 1}), '~1m');
+	t.is(m(1000 * 60 * 67, {unitCount: 1}), '~1h');
+	t.is(m(1000 * 60 * 67, {unitCount: 2}), '~1h 7m');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {unitCount: 1}), '~1y');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {unitCount: 2}), '~1y 154d');
+	t.is(m(1000 * 60 * 67 * 24 * 465, {unitCount: 3}), '~1y 154d 6h');
 });
 
 test('have a secDecimalDigits option', t => {


### PR DESCRIPTION
Currently, it is only possible to limit the number of units displayed to one unit. This would allow limiting to an arbitrary number of units without breaking the module's existing behavior.