### PR TITLE
Support internationalization

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,61 @@
 declare namespace prettyMilliseconds {
+	/* Language-specific time unit string representation */
+	interface LanguageUnits {
+		/**
+		The unit to display for years.
+		 */
+		readonly y: string;
+		/**
+		The unit to display for days.
+		 */
+		readonly d: string;
+		/**
+		The unit to display for hours.
+		 */
+		readonly h: string;
+		/**
+		The unit to display for minutes.
+		 */
+		readonly m: string;
+		/**
+		The unit to display for seconds.
+		 */
+		readonly s: string;
+		/**
+		The unit to display for milliseconds.
+		 */
+		readonly ms: string;
+		/**
+		The unit to display for microseconds.
+		 */
+		readonly µs: string;
+		/**
+		The unit to display for nanoseconds.
+		 */
+		readonly ns: string;
+	}
+
+	/* Language-specific configuration. */
+	interface Language {
+		/**
+		Short unit names (e.g. y, h, m, s, ms, µs, ns).
+		*/
+		readonly short: LanguageUnits;
+		/**
+		Long unit names (e.g. year, hour, minute, second, millisecond, microsecond, nanosecond).
+		*/
+		readonly long: LanguageUnits;
+		/**
+		 * Constructs the plural of the given word (e.g. day => days).
+		 *
+		 * @param word The word which should be pluralized.
+		 * @param count The value which determines whether the given word should be pluralized.
+		 *
+		 * @default undefined
+		 */
+		pluralize?: (word: string, count: number) => string;
+	}
+
 	interface Options {
 		/**
 		Number of digits to appear after the seconds decimal point.
@@ -61,6 +118,22 @@ declare namespace prettyMilliseconds {
 		@default false
 		*/
 		readonly formatSubMilliseconds?: boolean;
+
+		/**
+		The language to use when displaying units.
+		By default en, fr and es are available but you can add more with the languages option described hereafter.
+		This option fallbacks to en if it is undefined or if the targeted language was not found.
+
+		@default en
+		*/
+		readonly language?: string;
+
+		/**
+		Allows to define additional languages (en, fr and es are already available).
+
+		@default {}
+		*/
+		readonly languages?: { [language: string]: Language };
 	}
 }
 
@@ -97,6 +170,10 @@ prettyMilliseconds(100.400080, {formatSubMilliseconds: true})
 // Can be useful for time durations
 prettyMilliseconds(new Date(2014, 0, 1, 10, 40) - new Date(2014, 0, 1, 10, 5))
 //=> '35m'
+
+// Internationalization support
+prettyMilliseconds(1337000000, {language: 'fr'});
+//=> '15j 11h 23m 20s'
 ```
 */
 declare function prettyMilliseconds(

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,3 +18,12 @@ expectType<string>(
 expectType<string>(
 	prettyMilliseconds(1335669000, {formatSubMilliseconds: true})
 );
+expectType<string>(
+	prettyMilliseconds(1335669000, {language: 'xx', languages: {
+		xx: {
+			short: { y: 'Y', d: 'D', h: 'H', m: 'M', s: 'S', ms: 'MS', µs: 'US', ns: 'NS' },
+			long: { y: 'YEAR', d: 'DAY', h: 'HOUR', m: 'MINUTE', s: 'SECOND', ms: 'MILLISECOND', µs: 'MICROSECOND', ns: 'NANOSECOND' },
+			pluralize: (word, count) => count === 1 ? word : word + 'S'
+		}
+	}})
+);

--- a/languages.js
+++ b/languages.js
@@ -1,0 +1,42 @@
+module.exports = {
+	en: {
+		short: {y: 'y', d: 'd', h: 'h', m: 'm', s: 's', ms: 'ms', µs: 'µs', ns: 'ns'},
+		long: {
+			y: 'year',
+			d: 'day',
+			h: 'hour',
+			m: 'minute',
+			s: 'second',
+			ms: 'millisecond',
+			µs: 'microsecond',
+			ns: 'nanosecond'
+		},
+		pluralize: (word, count) => count === 1 ? word : word + 's'
+	},
+	fr: {
+		short: {y: 'a', d: 'j', h: 'h', m: 'm', s: 's', ms: 'ms', µs: 'µs', ns: 'ns'},
+		long: {
+			y: 'année',
+			d: 'jour',
+			h: 'heure',
+			m: 'minute',
+			s: 'seconde',
+			ms: 'milliseconde',
+			µs: 'microseconde',
+			ns: 'nanoseconde'
+		}
+	},
+	es: {
+		short: {y: 'a', d: 'd', h: 'h', m: 'm', s: 's', ms: 'ms', µs: 'µs', ns: 'ns'},
+		long: {
+			y: 'año',
+			d: 'día',
+			h: 'hora',
+			m: 'minuto',
+			s: 'segundo',
+			ms: 'milisegundo',
+			µs: 'microsecondo',
+			ns: 'nanosegundo'
+		}
+	}
+};

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,9 @@ prettyMilliseconds(100.400080, {formatSubMilliseconds: true})
 // Can be useful for time durations
 prettyMilliseconds(new Date(2014, 0, 1, 10, 40) - new Date(2014, 0, 1, 10, 5))
 //=> '35m'
+
+prettyMilliseconds(1337000000, {language: 'fr'});
+//=> '15j 11h 23m 20s'
 ```
 
 
@@ -118,6 +121,42 @@ Default: `false`
 
 Show microseconds and nanoseconds.
 
+##### language
+
+Type: `string`<br>
+Default: `en`
+
+The language to use when displaying units.
+By default `en`, `fr` and `es` are available but you can add more with the `languages` option described hereafter.
+This options fallbacks to `en` if it is `undefined` or if the targeted language was not found.
+
+##### languages
+
+Type: `object`<br>
+Default: `{}`
+
+Allows to define additional languages (`en`, `fr` and `es` are already available).
+
+Example:
+
+```js
+languages: {
+    en: {
+        short: { y: 'y', d: 'd', h: 'h', m: 'm', s: 's', ms: 'ms', µs: 'µs', ns: 'ns' },
+        long: {
+            y: 'year',
+            d: 'day',
+            h: 'hour',
+            m: 'minute',
+            s: 'second',
+            ms: 'millisecond',
+            µs: 'microsecond',
+            ns: 'nanosecond'
+        },
+        pluralize: (word, count) => count === 1 ? word : word + 's'
+    }
+}
+```
 
 ## Related
 


### PR DESCRIPTION
I've added very simple but extensible support for other languages than English.
As of now, I've only added French and Spanish since I only speak those 2 ones.

To use another language than English, just use the options below:

> ##### language
> 
> Type: `string`<br>
> Default: `en`
> 
> The language to use when displaying units.
> By default `en`, `fr` and `es` are available but you can add more with the `languages` option described hereafter.
> This options fallbacks to `en` if it is `undefined` or if the targeted language was not found.
> 
> ##### languages
> 
> Type: `object`<br>
> Default: `{}`
> 
> Allows to define additional languages (`en`, `fr` and `es` are already available).
> 
> Example:
> 
> ```js
> languages: {
>     en: {
>         short: { y: 'y', d: 'd', h: 'h', m: 'm', s: 's', ms: 'ms', µs: 'µs', ns: 'ns' },
>         long: {
>             y: 'year',
>             d: 'day',
>             h: 'hour',
>             m: 'minute',
>             s: 'second',
>             ms: 'millisecond',
>             µs: 'microsecond',
>             ns: 'nanosecond'
>         },
>         pluralize: (word, count) => count === 1 ? word : word + 's'
>     }
> }
> ```