### PR TITLE
Add `colonNotation` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare namespace prettyMilliseconds {
 		Display time using colon notation: `5h 1m 45s`→ `5:01:45`.
 
 		@default false
-		 */
+		*/
 		readonly colonNotation?: boolean;
 	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,13 @@ declare namespace prettyMilliseconds {
 		@default false
 		*/
 		readonly formatSubMilliseconds?: boolean;
+
+		/**
+		Display time using colon notation: `5h 1m 45s`→ `5:01:45`.
+
+		@default false
+		 */
+		readonly colonNotation?: boolean;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,14 @@ declare namespace prettyMilliseconds {
 		/**
 		Display time using colon notation: `5h 1m 45s` → `5:01:45`. Always shows time in at least minutes: `1s` → `0:01`
 
+		Useful when you want to display time without the time units, similar to a digital watch.
+
+		Setting `colonNotation` to `true` overrides the following options to `false`:
+		- `compact`
+		- `formatSubMilliseconds`
+		- `separateMilliseconds`
+		- `verbose`
+
 		@default false
 		*/
 		readonly colonNotation?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,7 @@ declare namespace prettyMilliseconds {
 		readonly formatSubMilliseconds?: boolean;
 
 		/**
-		Display time using colon notation: `5h 1m 45s`→ `5:01:45`.
+		Display time using colon notation: `5h 1m 45s` → `5:01:45`. Always shows time in at least minutes: `1s` → `0:01`
 
 		@default false
 		*/
@@ -96,6 +96,10 @@ prettyMilliseconds(1337, {compact: true});
 // `verbose` option
 prettyMilliseconds(1335669000, {verbose: true});
 //=> '15 days 11 hours 1 minute 9 seconds'
+
+// `colonNotation` option
+prettyMilliseconds(95500, {colonNotation: true});
+//=> '1:35.5'
 
 // `formatSubMilliseconds` option
 prettyMilliseconds(100.400080, {formatSubMilliseconds: true})

--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ module.exports = (milliseconds, options = {}) => {
 		options.millisecondsDecimalDigits = 0;
 	}
 
+	if (options.colonNotation) {
+		options.formatSubMilliseconds = false;
+	}
+
 	const result = [];
 
 	const add = (value, long, short, valueString) => {
@@ -24,9 +28,8 @@ module.exports = (milliseconds, options = {}) => {
 		const postfix = options.colonNotation ? '' : (options.verbose ? ' ' + pluralize(long, value) : short);
 		let valueStr = (valueString || value || '0').toString();
 		const wholeDigits = valueStr.includes('.') ? valueStr.split('.')[0].length : valueStr.length;
-		const paddingLength = ['ms', 'µs', 'ns'].includes(short) ? 3 : 2;
-		if (result.length > 0 && options.colonNotation) {
-			valueStr = '0'.repeat(paddingLength - wholeDigits) + valueStr;
+		if (result.length > 0 && options.colonNotation && !options.formatSubMilliseconds) {
+			valueStr = '0'.repeat(2 - wholeDigits) + valueStr;
 		}
 
 		result.push(prefix + valueStr + postfix);

--- a/index.js
+++ b/index.js
@@ -16,13 +16,20 @@ module.exports = (milliseconds, options = {}) => {
 	const result = [];
 
 	const add = (value, long, short, valueString) => {
-		if (value === 0) {
+		if ((result.length === 0 || !options.colonNotation) && value === 0 && !(options.colonNotation && short === 'm')) {
 			return;
 		}
 
-		const postfix = options.verbose ? ' ' + pluralize(long, value) : short;
+		const prefix = options.colonNotation && result.length > 0 ? ':' : '';
+		const postfix = options.colonNotation ? '' : (options.verbose ? ' ' + pluralize(long, value) : short);
+		let valueStr = (valueString || value || '0').toString();
+		const wholeDigits = valueStr.includes('.') ? valueStr.split('.')[0].length : valueStr.length;
+		const paddingLength = ['ms', 'µs', 'ns'].includes(short) ? 3 : 2;
+		if (result.length > 0 && options.colonNotation) {
+			valueStr = '0'.repeat(paddingLength - wholeDigits) + valueStr;
+		}
 
-		result.push((valueString || value) + postfix);
+		result.push(prefix + valueStr + postfix);
 	};
 
 	const secondsDecimalDigits =
@@ -101,5 +108,5 @@ module.exports = (milliseconds, options = {}) => {
 		return '~' + result.slice(0, Math.max(options.unitCount, 1)).join(' ');
 	}
 
-	return result.join(' ');
+	return options.colonNotation ? result.join('') : result.join(' ');
 };

--- a/index.js
+++ b/index.js
@@ -8,13 +8,16 @@ module.exports = (milliseconds, options = {}) => {
 		throw new TypeError('Expected a finite number');
 	}
 
+	if (options.colonNotation) {
+		options.compact = false;
+		options.formatSubMilliseconds = false;
+		options.separateMilliseconds = false;
+		options.verbose = false;
+	}
+
 	if (options.compact) {
 		options.secondsDecimalDigits = 0;
 		options.millisecondsDecimalDigits = 0;
-	}
-
-	if (options.colonNotation) {
-		options.formatSubMilliseconds = false;
 	}
 
 	const result = [];
@@ -24,15 +27,21 @@ module.exports = (milliseconds, options = {}) => {
 			return;
 		}
 
-		const prefix = options.colonNotation && result.length > 0 ? ':' : '';
-		const postfix = options.colonNotation ? '' : (options.verbose ? ' ' + pluralize(long, value) : short);
-		let valueStr = (valueString || value || '0').toString();
-		const wholeDigits = valueStr.includes('.') ? valueStr.split('.')[0].length : valueStr.length;
-		if (result.length > 0 && options.colonNotation && !options.formatSubMilliseconds) {
-			valueStr = '0'.repeat(2 - wholeDigits) + valueStr;
+		valueString = (valueString || value || '0').toString();
+		let prefix;
+		let suffix;
+		if (options.colonNotation) {
+			prefix = result.length > 0 ? ':' : '';
+			suffix = '';
+			const wholeDigits = valueString.includes('.') ? valueString.split('.')[0].length : valueString.length;
+			const minLength = result.length > 0 ? 2 : 1;
+			valueString = '0'.repeat(Math.max(0, minLength - wholeDigits)) + valueString;
+		} else {
+			prefix = '';
+			suffix = options.verbose ? ' ' + pluralize(long, value) : short;
 		}
 
-		result.push(prefix + valueStr + postfix);
+		result.push(prefix + valueString + suffix);
 	};
 
 	const secondsDecimalDigits =

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,3 +18,6 @@ expectType<string>(
 expectType<string>(
 	prettyMilliseconds(1335669000, {formatSubMilliseconds: true})
 );
+expectType<string>(
+	prettyMilliseconds(1335669000, {colonNotation: true})
+);

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,6 @@ prettyMilliseconds(100.400080, {formatSubMilliseconds: true})
 // Can be useful for time durations
 prettyMilliseconds(new Date(2014, 0, 1, 10, 40) - new Date(2014, 0, 1, 10, 5))
 //=> '35m'
-
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,8 @@ Show milliseconds separately. This means they won't be included in the decimal p
 Type: `boolean`\
 Default: `false`
 
+Show microseconds and nanoseconds.
+
 ##### colonNotation
 
 Type: `boolean`<br>

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,8 @@ Only show the first unit: `1h 10m` → `~1h`.
 
 Also ensures that `millisecondsDecimalDigits` and `secondsDecimalDigits` are both set to `0`.
 
+Setting `colonNotation` to `true` overrides this option.
+
 ##### unitCount
 
 Type: `number`\
@@ -109,12 +111,16 @@ Default: `false`
 
 Use full-length units: `5h 1m 45s` → `5 hours 1 minute 45 seconds`
 
+Setting `colonNotation` to `true` overrides this option.
+
 ##### separateMilliseconds
 
 Type: `boolean`\
 Default: `false`
 
 Show milliseconds separately. This means they won't be included in the decimal part of the seconds.
+
+Setting `colonNotation` to `true` overrides this option.
 
 ##### formatSubMilliseconds
 

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,13 @@ Default: `false`
 
 Show microseconds and nanoseconds.
 
+##### colonNotation
+
+Type: `boolean`<br>
+Default: `false`
+
+Use colon notation: `5h 1m 45s` → `5:01:45`
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ prettyMilliseconds(1337, {compact: true});
 prettyMilliseconds(1335669000, {verbose: true});
 //=> '15 days 11 hours 1 minute 9 seconds'
 
-// `verbose` option
+// `colonNotation` option
 prettyMilliseconds(95500, {colonNotation: true});
 //=> '1:35.5'
 
@@ -121,7 +121,7 @@ Show milliseconds separately. This means they won't be included in the decimal p
 Type: `boolean`\
 Default: `false`
 
-Show microseconds and nanoseconds.
+Show microseconds and nanoseconds. Setting `colonNotation` to `true` overrides this option.
 
 ##### colonNotation
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,10 @@ prettyMilliseconds(1337, {compact: true});
 prettyMilliseconds(1335669000, {verbose: true});
 //=> '15 days 11 hours 1 minute 9 seconds'
 
+// `verbose` option
+prettyMilliseconds(95500, {colonNotation: true});
+//=> '1:35.5'
+
 // `formatSubMilliseconds` option
 prettyMilliseconds(100.400080, {formatSubMilliseconds: true})
 //=> '100ms 400µs 80ns'
@@ -39,6 +43,7 @@ prettyMilliseconds(100.400080, {formatSubMilliseconds: true})
 // Can be useful for time durations
 prettyMilliseconds(new Date(2014, 0, 1, 10, 40) - new Date(2014, 0, 1, 10, 5))
 //=> '35m'
+
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -94,8 +94,6 @@ Only show the first unit: `1h 10m` → `~1h`.
 
 Also ensures that `millisecondsDecimalDigits` and `secondsDecimalDigits` are both set to `0`.
 
-Setting `colonNotation` to `true` overrides this option.
-
 ##### unitCount
 
 Type: `number`\
@@ -110,8 +108,6 @@ Default: `false`
 
 Use full-length units: `5h 1m 45s` → `5 hours 1 minute 45 seconds`
 
-Setting `colonNotation` to `true` overrides this option.
-
 ##### separateMilliseconds
 
 Type: `boolean`\
@@ -119,22 +115,25 @@ Default: `false`
 
 Show milliseconds separately. This means they won't be included in the decimal part of the seconds.
 
-Setting `colonNotation` to `true` overrides this option.
-
 ##### formatSubMilliseconds
 
 Type: `boolean`\
 Default: `false`
-
-Show microseconds and nanoseconds. Setting `colonNotation` to `true` overrides this option.
 
 ##### colonNotation
 
 Type: `boolean`<br>
 Default: `false`
 
-Use colon notation: `5h 1m 45s` → `5:01:45`
+Display time using colon notation: `5h 1m 45s` → `5:01:45`. Always shows time in at least minutes: `1s` → `0:01`
 
+Useful when you want to display time without the time units, similar to a digital watch.
+
+Setting `colonNotation` to `true` overrides the following options to `false`:
+- `compact`
+- `formatSubMilliseconds`
+- `separateMilliseconds`
+- `verbose`
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -221,3 +221,14 @@ test('properly rounds milliseconds with secondsDecimalDigits', t => {
 	t.is(fn((3600 * 1e3) - 1), '1 hour');
 	t.is(fn((2 * 3600 * 1e3) - 1), '2 hours');
 });
+
+test('work with colon output option', t => {
+	t.is(prettyMilliseconds(1000, {colonNotation: true}), '0:01');
+	t.is(prettyMilliseconds(1500, {colonNotation: true}), '0:01.5');
+	t.is(prettyMilliseconds(1543, {colonNotation: true, secondsDecimalDigits: 3}), '0:01.543');
+	t.is(prettyMilliseconds(1000 * 60, {colonNotation: true}), '1:00');
+	t.is(prettyMilliseconds(1000 * 90, {colonNotation: true}), '1:30');
+	t.is(prettyMilliseconds(95500, {colonNotation: true}), '1:35.5');
+	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + (500), {colonNotation: true}), '59:59.5');
+});
+

--- a/test.js
+++ b/test.js
@@ -229,6 +229,7 @@ test('work with colon output option', t => {
 	t.is(prettyMilliseconds(1000 * 60, {colonNotation: true}), '1:00');
 	t.is(prettyMilliseconds(1000 * 90, {colonNotation: true}), '1:30');
 	t.is(prettyMilliseconds(95500, {colonNotation: true}), '1:35.5');
+	t.is(prettyMilliseconds(95511.111, {colonNotation: true, formatSubMilliseconds: true}), '1:35.5');
 	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + (500), {colonNotation: true}), '59:59.5');
 });
 

--- a/test.js
+++ b/test.js
@@ -222,7 +222,7 @@ test('properly rounds milliseconds with secondsDecimalDigits', t => {
 	t.is(fn((2 * 3600 * 1e3) - 1), '2 hours');
 });
 
-test('work with colon output option', t => {
+test('`colonNotation` option', t => {
 	// Default formats
 	t.is(prettyMilliseconds(1000, {colonNotation: true}), '0:01');
 	t.is(prettyMilliseconds(1543, {colonNotation: true}), '0:01.5');
@@ -232,7 +232,8 @@ test('work with colon output option', t => {
 	t.is(prettyMilliseconds((1000 * 60 * 10) + 543, {colonNotation: true}), '10:00.5');
 	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true}), '59:59.5');
 	t.is(prettyMilliseconds((1000 * 60 * 60 * 15) + (1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true}), '15:59:59.5');
-	// SecondsDecimalDigits
+
+	// Together with `secondsDecimalDigits`
 	t.is(prettyMilliseconds(1543, {colonNotation: true, secondsDecimalDigits: 0}), '0:02');
 	t.is(prettyMilliseconds(1543, {colonNotation: true, secondsDecimalDigits: 1}), '0:01.5');
 	t.is(prettyMilliseconds(1543, {colonNotation: true, secondsDecimalDigits: 2}), '0:01.54');
@@ -243,7 +244,8 @@ test('work with colon output option', t => {
 	t.is(prettyMilliseconds(95543, {colonNotation: true, secondsDecimalDigits: 3}), '1:35.543');
 	t.is(prettyMilliseconds((1000 * 60 * 10) + 543, {colonNotation: true, secondsDecimalDigits: 3}), '10:00.543');
 	t.is(prettyMilliseconds((1000 * 60 * 60 * 15) + (1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true, secondsDecimalDigits: 3}), '15:59:59.543');
-	// KeepDecimalsOnWholeSeconds
+
+	// Together with `keepDecimalsOnWholeSeconds`
 	t.is(prettyMilliseconds(1000, {colonNotation: true, keepDecimalsOnWholeSeconds: true}), '0:01.0');
 	t.is(prettyMilliseconds(1000, {colonNotation: true, secondsDecimalDigits: 0, keepDecimalsOnWholeSeconds: true}), '0:01');
 	t.is(prettyMilliseconds(1000, {colonNotation: true, secondsDecimalDigits: 1, keepDecimalsOnWholeSeconds: true}), '0:01.0');
@@ -251,10 +253,10 @@ test('work with colon output option', t => {
 	t.is(prettyMilliseconds(1000 * 90, {colonNotation: true, keepDecimalsOnWholeSeconds: true}), '1:30.0');
 	t.is(prettyMilliseconds(1000 * 90, {colonNotation: true, secondsDecimalDigits: 3, keepDecimalsOnWholeSeconds: true}), '1:30.000');
 	t.is(prettyMilliseconds(1000 * 60 * 10, {colonNotation: true, secondsDecimalDigits: 3, keepDecimalsOnWholeSeconds: true}), '10:00.000');
-	// Make sure incompatible options fall back to colonNotation
+
+	// Make sure incompatible options fall back to `colonNotation`
 	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true, formatSubMilliseconds: true}), '59:59.5');
 	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true, separateMilliseconds: true}), '59:59.5');
 	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true, verbose: true}), '59:59.5');
 	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true, compact: true}), '59:59.5');
 });
-

--- a/test.js
+++ b/test.js
@@ -223,13 +223,38 @@ test('properly rounds milliseconds with secondsDecimalDigits', t => {
 });
 
 test('work with colon output option', t => {
+	// Default formats
 	t.is(prettyMilliseconds(1000, {colonNotation: true}), '0:01');
-	t.is(prettyMilliseconds(1500, {colonNotation: true}), '0:01.5');
-	t.is(prettyMilliseconds(1543, {colonNotation: true, secondsDecimalDigits: 3}), '0:01.543');
+	t.is(prettyMilliseconds(1543, {colonNotation: true}), '0:01.5');
 	t.is(prettyMilliseconds(1000 * 60, {colonNotation: true}), '1:00');
 	t.is(prettyMilliseconds(1000 * 90, {colonNotation: true}), '1:30');
-	t.is(prettyMilliseconds(95500, {colonNotation: true}), '1:35.5');
-	t.is(prettyMilliseconds(95511.111, {colonNotation: true, formatSubMilliseconds: true}), '1:35.5');
-	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + (500), {colonNotation: true}), '59:59.5');
+	t.is(prettyMilliseconds(95543, {colonNotation: true}), '1:35.5');
+	t.is(prettyMilliseconds((1000 * 60 * 10) + 543, {colonNotation: true}), '10:00.5');
+	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true}), '59:59.5');
+	t.is(prettyMilliseconds((1000 * 60 * 60 * 15) + (1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true}), '15:59:59.5');
+	// SecondsDecimalDigits
+	t.is(prettyMilliseconds(1543, {colonNotation: true, secondsDecimalDigits: 0}), '0:02');
+	t.is(prettyMilliseconds(1543, {colonNotation: true, secondsDecimalDigits: 1}), '0:01.5');
+	t.is(prettyMilliseconds(1543, {colonNotation: true, secondsDecimalDigits: 2}), '0:01.54');
+	t.is(prettyMilliseconds(1543, {colonNotation: true, secondsDecimalDigits: 3}), '0:01.543');
+	t.is(prettyMilliseconds(95543, {colonNotation: true, secondsDecimalDigits: 0}), '1:36');
+	t.is(prettyMilliseconds(95543, {colonNotation: true, secondsDecimalDigits: 1}), '1:35.5');
+	t.is(prettyMilliseconds(95543, {colonNotation: true, secondsDecimalDigits: 2}), '1:35.54');
+	t.is(prettyMilliseconds(95543, {colonNotation: true, secondsDecimalDigits: 3}), '1:35.543');
+	t.is(prettyMilliseconds((1000 * 60 * 10) + 543, {colonNotation: true, secondsDecimalDigits: 3}), '10:00.543');
+	t.is(prettyMilliseconds((1000 * 60 * 60 * 15) + (1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true, secondsDecimalDigits: 3}), '15:59:59.543');
+	// KeepDecimalsOnWholeSeconds
+	t.is(prettyMilliseconds(1000, {colonNotation: true, keepDecimalsOnWholeSeconds: true}), '0:01.0');
+	t.is(prettyMilliseconds(1000, {colonNotation: true, secondsDecimalDigits: 0, keepDecimalsOnWholeSeconds: true}), '0:01');
+	t.is(prettyMilliseconds(1000, {colonNotation: true, secondsDecimalDigits: 1, keepDecimalsOnWholeSeconds: true}), '0:01.0');
+	t.is(prettyMilliseconds(1000, {colonNotation: true, secondsDecimalDigits: 3, keepDecimalsOnWholeSeconds: true}), '0:01.000');
+	t.is(prettyMilliseconds(1000 * 90, {colonNotation: true, keepDecimalsOnWholeSeconds: true}), '1:30.0');
+	t.is(prettyMilliseconds(1000 * 90, {colonNotation: true, secondsDecimalDigits: 3, keepDecimalsOnWholeSeconds: true}), '1:30.000');
+	t.is(prettyMilliseconds(1000 * 60 * 10, {colonNotation: true, secondsDecimalDigits: 3, keepDecimalsOnWholeSeconds: true}), '10:00.000');
+	// Make sure incompatible options fall back to colonNotation
+	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true, formatSubMilliseconds: true}), '59:59.5');
+	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true, separateMilliseconds: true}), '59:59.5');
+	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true, verbose: true}), '59:59.5');
+	t.is(prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + 543, {colonNotation: true, compact: true}), '59:59.5');
 });
 


### PR DESCRIPTION
This PR adds option to format using colon notation. Examples from `tests.js`:

```javascript
prettyMilliseconds(1000, {colonNotation: true}) //=> '0:01'
prettyMilliseconds(1500, {colonNotation: true}) //=> '0:01.5'
prettyMilliseconds(1543, {colonNotation: true, secondsDecimalDigits: 3}) //=> '0:01.543'
prettyMilliseconds(1000 * 60, {colonNotation: true}) //=> '1:00'
prettyMilliseconds(1000 * 90, {colonNotation: true}) //=> '1:30'
prettyMilliseconds(95500, {colonNotation: true}) //=> '1:35.5'
prettyMilliseconds((1000 * 60 * 59) + (1000 * 59) + (500), {colonNotation: true}) //=> '59:59.5'
```