### PR TITLE
Fix milliseconds rounding inconsistency

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = (milliseconds, options = {}) => {
 
 	// Round up milliseconds for values lager than 1 minute - 50ms since these
 	// always need to be round up.
-	// (this fixes issues when rounding seconds independently of minute later)
+	// (this fixes issues when rounding seconds independently of minutes later)
 	if (
 		milliseconds >= (1000 * 60) - 50 &&
 		!options.separateMilliseconds &&

--- a/index.js
+++ b/index.js
@@ -79,11 +79,13 @@ module.exports = (milliseconds, options = {}) => {
 					options.millisecondsDecimalDigits :
 					0;
 
+			const roundedMiliseconds = millisecondsAndBelow >= 1 ?
+				Math.round(millisecondsAndBelow) :
+				Math.ceil(millisecondsAndBelow);
+
 			const millisecondsString = millisecondsDecimalDigits ?
 				millisecondsAndBelow.toFixed(millisecondsDecimalDigits) :
-				millisecondsAndBelow >= 1 ?
-					Math.round(millisecondsAndBelow) :
-					Math.ceil(millisecondsAndBelow);
+				roundedMiliseconds;
 
 			add(
 				parseFloat(millisecondsString, 10),

--- a/index.js
+++ b/index.js
@@ -37,6 +37,9 @@ module.exports = (milliseconds, options = {}) => {
 		}
 	}
 
+	// Round up milliseconds for values lager than 1 minute - 50ms since these
+	// always need to be round up.
+	// (this fixes issues when rounding seconds independently of minute later)
 	if (
 		milliseconds >= (1000 * 60) - 50 &&
 		!options.separateMilliseconds &&

--- a/index.js
+++ b/index.js
@@ -37,8 +37,11 @@ module.exports = (milliseconds, options = {}) => {
 		}
 	}
 
-	if (milliseconds >= (1000 * 60) - 50 && !options.separateMilliseconds &&
-		!options.formatSubMilliseconds) {
+	if (
+		milliseconds >= (1000 * 60) - 50 &&
+		!options.separateMilliseconds &&
+		!options.formatSubMilliseconds
+	) {
 		const difference = 60 - (milliseconds % 60);
 		if (difference <= 50) {
 			milliseconds += difference;

--- a/index.js
+++ b/index.js
@@ -37,6 +37,14 @@ module.exports = (milliseconds, options = {}) => {
 		}
 	}
 
+	if (milliseconds > 1000 && !options.separateMilliseconds &&
+		!options.formatSubMilliseconds) {
+		const difference = 60 - milliseconds % 60
+		if (difference < 20) {
+			milliseconds += difference;
+		}
+	}
+
 	const parsed = parseMilliseconds(milliseconds);
 
 	add(Math.trunc(parsed.days / 365), 'year', 'y');
@@ -67,7 +75,9 @@ module.exports = (milliseconds, options = {}) => {
 
 			const millisecondsString = millisecondsDecimalDigits ?
 				millisecondsAndBelow.toFixed(millisecondsDecimalDigits) :
-				Math.ceil(millisecondsAndBelow);
+				millisecondsAndBelow >= 1 ?
+					Math.round(millisecondsAndBelow) :
+					Math.ceil(millisecondsAndBelow);
 
 			add(
 				parseFloat(millisecondsString, 10),

--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@ module.exports = (milliseconds, options = {}) => {
 		}
 	}
 
-	if (milliseconds > 1000 && !options.separateMilliseconds &&
+	if (milliseconds >= (1000 * 60) - 50 && !options.separateMilliseconds &&
 		!options.formatSubMilliseconds) {
 		const difference = 60 - milliseconds % 60
-		if (difference < 50) {
+		if (difference <= 50) {
 			milliseconds += difference;
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = (milliseconds, options = {}) => {
 
 	if (milliseconds >= (1000 * 60) - 50 && !options.separateMilliseconds &&
 		!options.formatSubMilliseconds) {
-		const difference = 60 - milliseconds % 60
+		const difference = 60 - (milliseconds % 60);
 		if (difference <= 50) {
 			milliseconds += difference;
 		}

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = (milliseconds, options = {}) => {
 	if (milliseconds > 1000 && !options.separateMilliseconds &&
 		!options.formatSubMilliseconds) {
 		const difference = 60 - milliseconds % 60
-		if (difference < 20) {
+		if (difference < 50) {
 			milliseconds += difference;
 		}
 	}

--- a/test.js
+++ b/test.js
@@ -16,6 +16,7 @@ test('prettify milliseconds', t => {
 	t.is(prettyMilliseconds(1000 * 60 * 60 * 999), '41d 15h');
 	t.is(prettyMilliseconds(1000 * 60 * 60 * 24 * 465), '1y 100d');
 	t.is(prettyMilliseconds(1000 * 60 * 67 * 24 * 465), '1y 154d 6h');
+	t.is(prettyMilliseconds(119999), '2m');
 });
 
 test('have a compact option', t => {
@@ -43,8 +44,8 @@ test('have a secondsDecimalDigits option', t => {
 });
 
 test('have a millisecondsDecimalDigits option', t => {
-	t.is(prettyMilliseconds(33.333), '34ms');
-	t.is(prettyMilliseconds(33.333, {millisecondsDecimalDigits: 0}), '34ms');
+	t.is(prettyMilliseconds(33.333), '33ms');
+	t.is(prettyMilliseconds(33.333, {millisecondsDecimalDigits: 0}), '33ms');
 	t.is(prettyMilliseconds(33.333, {millisecondsDecimalDigits: 4}), '33.3330ms');
 });
 


### PR DESCRIPTION
While everything below `0.1ms` keeps the old behavior and gets rounded up to `1ms`, everything over that uses `Math.round`.
Also fixes the issue with 11999 milliseconds rounding to `1m 60s`.
Fixes #38