### PR TITLE
Remove tilde prefix from `compact` output

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ declare namespace prettyMilliseconds {
 		readonly keepDecimalsOnWholeSeconds?: boolean;
 
 		/**
-		Only show the first unit: `1h 10m` → `~1h`.
+		Only show the first unit: `1h 10m` → `1h`.
 
 		Also ensures that `millisecondsDecimalDigits` and `secondsDecimalDigits` are both set to `0`.
 
@@ -84,7 +84,7 @@ prettyMilliseconds(133);
 
 // `compact` option
 prettyMilliseconds(1337, {compact: true});
-//=> '~1s'
+//=> '1s'
 
 // `verbose` option
 prettyMilliseconds(1335669000, {verbose: true});

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = (milliseconds, options = {}) => {
 	}
 
 	if (options.compact) {
-		return '~' + result[0];
+		return result[0];
 	}
 
 	if (typeof options.unitCount === 'number') {

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ prettyMilliseconds(133);
 
 // `compact` option
 prettyMilliseconds(1337, {compact: true});
-//=> '~1s'
+//=> '1s'
 
 // `verbose` option
 prettyMilliseconds(1335669000, {verbose: true});
@@ -86,7 +86,7 @@ Useful when you are showing a number of seconds spent on an operation and don't 
 Type: `boolean`<br>
 Default: `false`
 
-Only show the first unit: `1h 10m` → `~1h`.
+Only show the first unit: `1h 10m` → `1h`.
 
 Also ensures that `millisecondsDecimalDigits` and `secondsDecimalDigits` are both set to `0`.
 

--- a/test.js
+++ b/test.js
@@ -19,10 +19,10 @@ test('prettify milliseconds', t => {
 });
 
 test('have a compact option', t => {
-	t.is(prettyMilliseconds(1000 + 4, {compact: true}), '~1s');
-	t.is(prettyMilliseconds(1000 * 60 * 60 * 999, {compact: true}), '~41d');
-	t.is(prettyMilliseconds(1000 * 60 * 60 * 24 * 465, {compact: true}), '~1y');
-	t.is(prettyMilliseconds(1000 * 60 * 67 * 24 * 465, {compact: true}), '~1y');
+	t.is(prettyMilliseconds(1000 + 4, {compact: true}), '1s');
+	t.is(prettyMilliseconds(1000 * 60 * 60 * 999, {compact: true}), '41d');
+	t.is(prettyMilliseconds(1000 * 60 * 60 * 24 * 465, {compact: true}), '1y');
+	t.is(prettyMilliseconds(1000 * 60 * 67 * 24 * 465, {compact: true}), '1y');
 });
 
 test('have a unitCount option', t => {
@@ -97,19 +97,19 @@ test('work with verbose and compact options', t => {
 		compact: true
 	});
 
-	t.is(fn(1000), '~1 second');
-	t.is(fn(1000 + 400), '~1 second');
-	t.is(fn((1000 * 2) + 400), '~2 seconds');
-	t.is(fn(1000 * 5), '~5 seconds');
-	t.is(fn(1000 * 55), '~55 seconds');
-	t.is(fn(1000 * 67), '~1 minute');
-	t.is(fn(1000 * 60 * 5), '~5 minutes');
-	t.is(fn(1000 * 60 * 67), '~1 hour');
-	t.is(fn(1000 * 60 * 60 * 12), '~12 hours');
-	t.is(fn(1000 * 60 * 60 * 40), '~1 day');
-	t.is(fn(1000 * 60 * 60 * 999), '~41 days');
-	t.is(fn(1000 * 60 * 60 * 24 * 465), '~1 year');
-	t.is(fn(1000 * 60 * 67 * 24 * 750), '~2 years');
+	t.is(fn(1000), '1 second');
+	t.is(fn(1000 + 400), '1 second');
+	t.is(fn((1000 * 2) + 400), '2 seconds');
+	t.is(fn(1000 * 5), '5 seconds');
+	t.is(fn(1000 * 55), '55 seconds');
+	t.is(fn(1000 * 67), '1 minute');
+	t.is(fn(1000 * 60 * 5), '5 minutes');
+	t.is(fn(1000 * 60 * 67), '1 hour');
+	t.is(fn(1000 * 60 * 60 * 12), '12 hours');
+	t.is(fn(1000 * 60 * 60 * 40), '1 day');
+	t.is(fn(1000 * 60 * 60 * 999), '41 days');
+	t.is(fn(1000 * 60 * 60 * 24 * 465), '1 year');
+	t.is(fn(1000 * 60 * 67 * 24 * 750), '2 years');
 });
 
 test('work with verbose and unitCount options', t => {
@@ -173,9 +173,9 @@ test('work with verbose and formatSubMilliseconds options', t => {
 });
 
 test('compact option overrides unitCount option', t => {
-	t.is(prettyMilliseconds(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 1}), '~1 year');
-	t.is(prettyMilliseconds(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 2}), '~1 year');
-	t.is(prettyMilliseconds(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 3}), '~1 year');
+	t.is(prettyMilliseconds(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 1}), '1 year');
+	t.is(prettyMilliseconds(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 2}), '1 year');
+	t.is(prettyMilliseconds(1000 * 60 * 67 * 24 * 465, {verbose: true, compact: true, unitCount: 3}), '1 year');
 });
 
 test('work with separateMilliseconds and formatSubMilliseconds options', t => {


### PR DESCRIPTION
Resolves #32 

```js
prettyMilliseconds(1337, {compact: true});
//=> '1s'
```

**Question:** In this PR, I removed the `~` from the output when `compact: true`, as described in the issue. I noticed that the `unitCount` option also adds a `~` prefix to its output. Should it be removed as well?