### PR TITLE
⚛️ Add support for React Native + Expo

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@ import parseMilliseconds from 'parse-ms';
 
 const pluralize = (word, count) => count === 1 ? word : `${word}s`;
 
-const SECOND_ROUNDING_EPSILON = 0.000_000_1;
+const SECOND_ROUNDING_EPSILON =
+	(typeof navigator !== 'undefined' && navigator.product === 'ReactNative')
+	? 0.0000001
+	: parseFloat('0.000_000_1'.split('_').join(''));
 
 export default function prettyMilliseconds(milliseconds, options = {}) {
 	if (!Number.isFinite(milliseconds)) {


### PR DESCRIPTION
# Description
This package breaks React Native and Expo based applications since numeric separators (ECMAScript 2021 feature) are not yet supported. This patch fixes it by checking for the environment and initializing the `SECOND_ROUNDING_EPSILON` constant.

# Screenshots
The error that is fixed in this patch:

![Expo Error](https://user-images.githubusercontent.com/36959928/185761818-0f0d26e2-da76-408c-adc7-03f2da23142f.jpeg)

